### PR TITLE
refactor: serialization

### DIFF
--- a/bancho-packet/src/buffer/serialization.rs
+++ b/bancho-packet/src/buffer/serialization.rs
@@ -1,56 +1,72 @@
 use bytes::{BufMut, BytesMut, Buf, Bytes};
+use std::error::Error;
 
-pub trait BytesMutExt {
+pub trait BytesMutExt<B: ByteSlice + GrowableByteSlice> {
     fn put_header(&mut self, id: i16);
     fn fix_header(&mut self, start: usize);
     fn len(&self) -> usize;
-    
+
     fn put_bool(&mut self, val: bool);
     fn put_uleb(&mut self, len: usize);
     fn put_string(&mut self, string: &str);
-    
-    fn get_bool(&mut self) -> bool;
-    fn get_uleb(&mut self) -> usize;
-    fn get_string(&mut self) -> String;
 
-    fn with_header(&mut self, id: i16, f: impl FnOnce(&mut Self) -> ()) {
+    fn get_bool(&mut self) -> Result<bool, Box<dyn Error>>;
+    fn get_uleb(&mut self) -> Result<usize, Box<dyn Error>>;
+    fn get_string(&mut self) -> Result<String, Box<dyn Error>>;
+
+    fn with_header<F, R>(&mut self, id: i16, f: F) -> Result<R, Box<dyn Error>>
+    where
+        F: FnOnce(&mut Self) -> Result<R, Box<dyn Error>>,
+    {
         // record start and put header
         let start = self.len();
         self.put_header(id);
-        
+
         // run caller provided code
-        f(self);
-        
+        let result = f(self)?;
+
         // cleanup
         self.fix_header(start);
+
+        Ok(result)
     }
 }
 
 pub trait BytesExt {
-    fn take_while(&mut self, f: impl FnMut(u8) -> bool) -> Bytes;
+    fn take_while(&mut self, f: impl FnMut(u8) -> bool) -> Result<Bytes, Box<dyn Error>>;
 }
 
 impl BytesMutExt for BytesMut {
     fn len(&self) -> usize {
-        BytesMut::len(self) // call BytesMut.len() not BytesMutExt.len()
+        // call BytesMut::len() to get the length of the buffer
+        BytesMut::len(self)
     }
 
-    fn put_header(&mut self, id: i16) {
-        self.put_i16_le(id);
-        self.put_bool(false);
-        self.put_u32_le(0);
+    fn put_header(&mut self, id: i16) -> Result<(), Box<dyn Error>> {
+        self.put_i16_le(id)?;
+        self.put_bool(false)?;
+        self.put_u32_le(0)?;
+
+        Ok(())
     }
 
-    fn fix_header(&mut self, start: usize) {
+    fn fix_header(&mut self, start: usize) -> Result<(), Box<dyn Error>> {
+        if start >= self.len() {
+            return Err(Box::new(Error::InvalidInput));
+        }
+
         let length = self.len() - start - 7;
-        (self[start + 3]) = length as u8;
+        self[start + 3] = length as u8;
+
+        Ok(())
     }
 
-    fn put_bool(&mut self, val: bool) {
-        self.put_u8(val as u8);
+    fn put_bool(&mut self, val: bool) -> Result<(), Box<dyn Error>> {
+        self.put_u8(val as u8)?;
+        Ok(())
     }
 
-    fn put_uleb(&mut self, mut len: usize) {
+    fn put_uleb(&mut self, mut len: usize) -> Result<(), Box<dyn Error>> {
         let mut uleb: Vec<u8> = vec![0; 32];
 
         let mut uleb_len: usize = 0;
@@ -68,78 +84,92 @@ impl BytesMutExt for BytesMut {
 
         uleb.retain(|&x| x != 0);
 
-        self.put(uleb.as_slice());
+        self.put(uleb.as_slice())?;
+
+        Ok(())
     }
-    fn put_string(&mut self, string: &str) {
+    
+    fn put_string(&mut self, string: &str) -> Result<(), Box<dyn Error>> {
         let length = string.len();
- 
-        self.put_u8(0xb);
-        self.put_uleb(length);
-        self.put(string.as_bytes());
+
+        self.put_u8(0xb)?;
+        self.put_uleb(length)?;
+        self.put(string.as_bytes())?;
+
+        Ok(())
     }
 
-    fn get_bool(&mut self) -> bool {
-        self.get_u8() != 0
+    fn get_bool(&mut self) -> Result<bool, Box<dyn Error>> {
+        let byte = self.get_u8()?;
+        Ok(byte != 0)
     }
 
-    fn get_uleb(&mut self) -> usize {
+    fn get_uleb(&mut self) -> Result<usize, Box<dyn Error>> {
         let mut result = 0;
         let mut shift = 0;
 
-        let mut byte = self.get_u8();
+        // read the first byte
+        let mut byte = self.get_u8()?;
 
+        // check if the highest bit is set
         if (byte & 0x80) == 0 {
+            // the value is one byte long, return it
+            return Ok((byte & 0x7f) as usize);
+        }
+
+        // the value is longer than one byte, read the remaining bytes
+        loop {
             result |= (byte & 0x7f) << shift;
-        } else {
-            let mut end = false;
+            shift += 7;
 
-            while !end {
-                if shift > 0 {
-                    byte = self.get_u8();
-                }
-
-                result |= (byte & 0x7f) << shift;
-                if (byte & 0x80) == 0 {
-                    end = true;
-                }
-                shift += 7;
+            byte = self.get_u8()?;
+            if (byte & 0x80) == 0 {
+                // the highest bit is not set, the value has ended
+                break;
             }
         }
 
-        result as usize
+        result |= (byte & 0x7f) << shift;
+
+        Ok(result as usize)
     }
 
-    fn get_string(&mut self) -> String {
-        let _ = self.get_u8();
-        let length = self.get_uleb();
-        let mut string = "".to_string();
+    fn get_string(&mut self) -> Result<String, Box<dyn Error>> {
+        // read the length of the string
+        let _ = self.get_u8()?;
+        let length = self.get_uleb()?;
 
-        if length > 0 {
-            let mut i = 0;
-
-            while i < length + 1 {
-                let current_char = self.get(i);
-                let chr = match current_char {
-                    Some(x) => *x as char,
-                    None => '\0',
-                };
-
-                string = format!("{}{}", string, chr); //;
-                i += 1;
-            }
-
-            self.advance(length);
+        // check if the length is non-zero
+        if length == 0 {
+            return Ok(String::new());
         }
+
+        // read the characters of the string
+        let mut string = String::with_capacity(length);
+        for _ in 0..length {
+            let current_char = self.get(0)?;
+            string.push(*current_char as char);
+            self.advance(1);
+        }
+
+        // remove any null characters at the end of the string
         string.retain(|x| x != '\0' && x != '\u{b}');
-        string
+
+        Ok(string)
     }
 
     
 }
 
 impl BytesExt for Bytes {
-// TODO: This doesnt need to copy, could just slice into the buf
-    fn take_while(&mut self, mut f: impl FnMut(u8) -> bool) -> Bytes {
+    /// returns a slice of this `Bytes` value that contains the elements 
+    /// for which the given predicate returns `true`.
+    fn take_while(&mut self, mut f: impl FnMut(u8) -> bool) -> &[u8] {
+        // return early if the buffer is empty
+        if self.is_empty() {
+            return &[];
+        }
+
         let mut len = 0;
         while let Some(b) = self.get(len) {
             if !f(*b) {
@@ -148,7 +178,9 @@ impl BytesExt for Bytes {
             len += 1;
         }
 
-        self.copy_to_bytes(len)
+        // return a slice of the original buffer
+        let (left, _right) = self.split_to(len);
+        left
     }
 }
 


### PR DESCRIPTION
added general type parameter `b` to trait definitions, and constrained it to implement `ByteSlice` and `GrowableBytesSlice` traits modified return types of `get_bool`, `get_uleb`, `get_string` and `with_header` to return a `Result` type instead of a bare value, this allows the caller to handle cases where an error may occur (e.g. incorrect or insufficient data passed ot buffer) more elegantly

modified the return type of `take_while` to return a splice of the original buffer instead of copying, used `split_to` to split the `Bytes` value into two parts at the desired position, and returned the first part added an early return if the buffer has no data/is empty, to avoid unnecessary processing

among other things, added error handling etc etc u get the idea

let me know if this is suitable and make edits if you need to thanks